### PR TITLE
fix: add firestore user role

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -24,6 +24,10 @@ contributors:
 
 billingRequired: true
 
+roles:
+  - role: datastore.user
+    reason: Allows this extension to access Cloud Firestore to read and process added email documents.
+
 resources:
   - name: processDocumentCreated
     type: firebaseextensions.v1beta.function


### PR DESCRIPTION
In production this extension will need this permission. It probably worked fine with the emulator before, but it breaks in prod otherwise.